### PR TITLE
Add inline command snapshots to repo-aware skills

### DIFF
--- a/skills/capacitor-app-upgrade-v4-to-v5/SKILL.md
+++ b/skills/capacitor-app-upgrade-v4-to-v5/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: capacitor-app-upgrade-v4-to-v5
 description: Guides the agent through upgrading a Capacitor app from v4 to v5. Use when the project is on Capacitor 4 and needs the v5 migration path. Do not use for other major versions, plugin-only upgrades, or non-Capacitor apps.
+allowed-tools:
+  - Bash(node -e *)
 ---
 
 # Capacitor App Upgrade v4 to v5
@@ -13,9 +15,14 @@ Upgrade a Capacitor app from version 4 to version 5.
 - User wants the exact v4 to v5 migration path
 - User needs v5-specific native and package updates
 
+## Live Project Snapshot
+
+Current Capacitor packages from `package.json`:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
 ## Procedure
 
-1. Read the current `@capacitor/core` version from `package.json`.
+1. Start from the injected package snapshot and confirm the current `@capacitor/core` version.
 2. Update all `@capacitor/*` packages to the v5-compatible range.
 3. Review the v4 to v5 migration notes before editing native files.
 4. Run `npm install`.

--- a/skills/capacitor-app-upgrade-v5-to-v6/SKILL.md
+++ b/skills/capacitor-app-upgrade-v5-to-v6/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: capacitor-app-upgrade-v5-to-v6
 description: Guides the agent through upgrading a Capacitor app from v5 to v6. Use when the project is on Capacitor 5 and needs the v6 migration path. Do not use for other major versions, plugin-only upgrades, or non-Capacitor apps.
+allowed-tools:
+  - Bash(node -e *)
 ---
 
 # Capacitor App Upgrade v5 to v6
@@ -13,9 +15,14 @@ Upgrade a Capacitor app from version 5 to version 6.
 - User wants the exact v5 to v6 migration path
 - User needs v6-specific native and package updates
 
+## Live Project Snapshot
+
+Current Capacitor packages from `package.json`:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
 ## Procedure
 
-1. Read the current `@capacitor/core` version from `package.json`.
+1. Start from the injected package snapshot and confirm the current `@capacitor/core` version.
 2. Update all `@capacitor/*` packages to the v6-compatible range.
 3. Review the v5 to v6 migration notes before editing native files.
 4. Run `npm install`.

--- a/skills/capacitor-app-upgrade-v6-to-v7/SKILL.md
+++ b/skills/capacitor-app-upgrade-v6-to-v7/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: capacitor-app-upgrade-v6-to-v7
 description: Guides the agent through upgrading a Capacitor app from v6 to v7. Use when the project is on Capacitor 6 and needs the v7 migration path. Do not use for other major versions, plugin-only upgrades, or non-Capacitor apps.
+allowed-tools:
+  - Bash(node -e *)
 ---
 
 # Capacitor App Upgrade v6 to v7
@@ -13,9 +15,14 @@ Upgrade a Capacitor app from version 6 to version 7.
 - User wants the exact v6 to v7 migration path
 - User needs v7-specific native and package updates
 
+## Live Project Snapshot
+
+Current Capacitor packages from `package.json`:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
 ## Procedure
 
-1. Read the current `@capacitor/core` version from `package.json`.
+1. Start from the injected package snapshot and confirm the current `@capacitor/core` version.
 2. Update all `@capacitor/*` packages to the v7-compatible range.
 3. Review the v6 to v7 migration notes before editing native files.
 4. Run `npm install`.

--- a/skills/capacitor-app-upgrade-v7-to-v8/SKILL.md
+++ b/skills/capacitor-app-upgrade-v7-to-v8/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: capacitor-app-upgrade-v7-to-v8
 description: Guides the agent through upgrading a Capacitor app from v7 to v8. Use when the project is on Capacitor 7 and needs the v8 migration path. Do not use for other major versions, plugin-only upgrades, or non-Capacitor apps.
+allowed-tools:
+  - Bash(node -e *)
 ---
 
 # Capacitor App Upgrade v7 to v8
@@ -13,9 +15,14 @@ Upgrade a Capacitor app from version 7 to version 8.
 - User wants the exact v7 to v8 migration path
 - User needs v8-specific native and package updates
 
+## Live Project Snapshot
+
+Current Capacitor packages from `package.json`:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
 ## Procedure
 
-1. Read the current `@capacitor/core` version from `package.json`.
+1. Start from the injected package snapshot and confirm the current `@capacitor/core` version.
 2. Update all `@capacitor/*` packages to the v8-compatible range.
 3. Review the v7 to v8 migration notes before editing native files.
 4. Run `npm install`.

--- a/skills/capacitor-app-upgrades/SKILL.md
+++ b/skills/capacitor-app-upgrades/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-app-upgrades
 description: Guides the agent through upgrading a Capacitor app project to a newer major version. Covers multi-version jumps, dependency alignment, native platform checks, and verification. Do not use for plugin library upgrades or non-Capacitor mobile frameworks.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor App Upgrade
@@ -13,11 +16,19 @@ Upgrade a Capacitor app project to a newer major version.
 - User is preparing for a multi-version jump
 - User needs a safe fallback when automated migration does not complete cleanly
 
+## Live Project Snapshot
+
+Current Capacitor packages from `package.json`:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
+Native and Capacitor config paths:
+!`find . -maxdepth 3 \( -name 'capacitor.config.json' -o -name 'capacitor.config.ts' -o -name 'capacitor.config.js' -o -path './ios' -o -path './android' \)`
+
 ## Procedures
 
 ### Step 1: Detect the Current Version
 
-Read `@capacitor/core` from `package.json` in `dependencies` or `devDependencies`.
+Start from the injected snapshot above, then confirm `@capacitor/core` in `package.json` if anything looks inconsistent.
 
 If the target version is not specified, ask the user to confirm an explicit major version before proceeding.
 

--- a/skills/capacitor-plugin-upgrade-v4-to-v5/SKILL.md
+++ b/skills/capacitor-plugin-upgrade-v4-to-v5/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-plugin-upgrade-v4-to-v5
 description: Guides the agent through upgrading a Capacitor plugin from v4 to v5. Use when the plugin targets Capacitor 4 and needs the v5 migration path. Do not use for app upgrades, other major versions, or non-Capacitor plugins.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor Plugin Upgrade v4 to v5
@@ -13,9 +16,17 @@ Upgrade a Capacitor plugin from version 4 to version 5.
 - User wants the exact v4 to v5 migration path
 - User needs v5-specific native and package updates
 
+## Live Project Snapshot
+
+Plugin and Capacitor package snapshot:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=['package.name='+(pkg.name||''),'package.version='+(pkg.version||'')];for(const section of ['peerDependencies','dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.join('\n'))"`
+
+Example and native project paths:
+!`find . -maxdepth 3 \( -path './example-app' -o -path './ios' -o -path './android' \)`
+
 ## Procedure
 
-1. Read the plugin's `package.json` and current Capacitor peer dependency range.
+1. Start from the injected snapshot and confirm the current Capacitor peer dependency range in `package.json`.
 2. Update the peer dependency range to Capacitor 5.
 3. Review the v4 to v5 migration notes before editing native files.
 4. Update the example app if it exists.

--- a/skills/capacitor-plugin-upgrade-v5-to-v6/SKILL.md
+++ b/skills/capacitor-plugin-upgrade-v5-to-v6/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-plugin-upgrade-v5-to-v6
 description: Guides the agent through upgrading a Capacitor plugin from v5 to v6. Use when the plugin targets Capacitor 5 and needs the v6 migration path. Do not use for app upgrades, other major versions, or non-Capacitor plugins.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor Plugin Upgrade v5 to v6
@@ -13,9 +16,17 @@ Upgrade a Capacitor plugin from version 5 to version 6.
 - User wants the exact v5 to v6 migration path
 - User needs v6-specific native and package updates
 
+## Live Project Snapshot
+
+Plugin and Capacitor package snapshot:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=['package.name='+(pkg.name||''),'package.version='+(pkg.version||'')];for(const section of ['peerDependencies','dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.join('\n'))"`
+
+Example and native project paths:
+!`find . -maxdepth 3 \( -path './example-app' -o -path './ios' -o -path './android' \)`
+
 ## Procedure
 
-1. Read the plugin's `package.json` and current Capacitor peer dependency range.
+1. Start from the injected snapshot and confirm the current Capacitor peer dependency range in `package.json`.
 2. Update the peer dependency range to Capacitor 6.
 3. Review the v5 to v6 migration notes before editing native files.
 4. Update the example app if it exists.

--- a/skills/capacitor-plugin-upgrade-v6-to-v7/SKILL.md
+++ b/skills/capacitor-plugin-upgrade-v6-to-v7/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-plugin-upgrade-v6-to-v7
 description: Guides the agent through upgrading a Capacitor plugin from v6 to v7. Use when the plugin targets Capacitor 6 and needs the v7 migration path. Do not use for app upgrades, other major versions, or non-Capacitor plugins.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor Plugin Upgrade v6 to v7
@@ -13,9 +16,17 @@ Upgrade a Capacitor plugin from version 6 to version 7.
 - User wants the exact v6 to v7 migration path
 - User needs v7-specific native and package updates
 
+## Live Project Snapshot
+
+Plugin and Capacitor package snapshot:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=['package.name='+(pkg.name||''),'package.version='+(pkg.version||'')];for(const section of ['peerDependencies','dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.join('\n'))"`
+
+Example and native project paths:
+!`find . -maxdepth 3 \( -path './example-app' -o -path './ios' -o -path './android' \)`
+
 ## Procedure
 
-1. Read the plugin's `package.json` and current Capacitor peer dependency range.
+1. Start from the injected snapshot and confirm the current Capacitor peer dependency range in `package.json`.
 2. Update the peer dependency range to Capacitor 7.
 3. Review the v6 to v7 migration notes before editing native files.
 4. Update the example app if it exists.

--- a/skills/capacitor-plugin-upgrade-v7-to-v8/SKILL.md
+++ b/skills/capacitor-plugin-upgrade-v7-to-v8/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-plugin-upgrade-v7-to-v8
 description: Guides the agent through upgrading a Capacitor plugin from v7 to v8. Use when the plugin targets Capacitor 7 and needs the v8 migration path. Do not use for app upgrades, other major versions, or non-Capacitor plugins.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor Plugin Upgrade v7 to v8
@@ -13,9 +16,17 @@ Upgrade a Capacitor plugin from version 7 to version 8.
 - User wants the exact v7 to v8 migration path
 - User needs v8-specific native and package updates
 
+## Live Project Snapshot
+
+Plugin and Capacitor package snapshot:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=['package.name='+(pkg.name||''),'package.version='+(pkg.version||'')];for(const section of ['peerDependencies','dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.join('\n'))"`
+
+Example and native project paths:
+!`find . -maxdepth 3 \( -path './example-app' -o -path './ios' -o -path './android' \)`
+
 ## Procedure
 
-1. Read the plugin's `package.json` and current Capacitor peer dependency range.
+1. Start from the injected snapshot and confirm the current Capacitor peer dependency range in `package.json`.
 2. Update the peer dependency range to Capacitor 8.
 3. Review the v7 to v8 migration notes before editing native files.
 4. Update the example app if it exists.

--- a/skills/capacitor-plugin-upgrades/SKILL.md
+++ b/skills/capacitor-plugin-upgrades/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: capacitor-plugin-upgrades
 description: Guides the agent through upgrading a Capacitor plugin to a newer major version. Covers dependency alignment, native platform changes, example app verification, and multi-version jumps. Do not use for app project upgrades or non-Capacitor plugin frameworks.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Capacitor Plugin Upgrade
@@ -13,11 +16,19 @@ Upgrade a Capacitor plugin to a newer major version.
 - User needs help adapting native code to a new Capacitor major release
 - User wants to verify the plugin still works in its example app after the upgrade
 
+## Live Project Snapshot
+
+Plugin and Capacitor package snapshot:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=['package.name='+(pkg.name||''),'package.version='+(pkg.version||'')];for(const section of ['peerDependencies','dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@capacitor/'))out.push(section+'.'+name+'='+version)}}console.log(out.join('\n'))"`
+
+Example and native project paths:
+!`find . -maxdepth 3 \( -path './example-app' -o -path './ios' -o -path './android' -o -name 'capacitor.config.json' -o -name 'capacitor.config.ts' -o -name 'capacitor.config.js' \)`
+
 ## Procedures
 
 ### Step 1: Detect the Current Version
 
-Read the current `@capacitor/core` version from `package.json` and inspect the plugin package version.
+Start from the injected snapshot above, then inspect `package.json` if the Capacitor ranges or package version need confirmation.
 
 Ask the user to confirm the exact target major version before proceeding.
 

--- a/skills/cordova-to-capacitor/SKILL.md
+++ b/skills/cordova-to-capacitor/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cordova-to-capacitor
 description: Complete guide for migrating from Apache Cordova to Capacitor. Use this skill when users need to modernize a Cordova/PhoneGap app to Capacitor, migrate plugins, or understand platform differences.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Cordova to Capacitor Migration
@@ -14,6 +17,14 @@ Step-by-step guide for migrating from Apache Cordova/PhoneGap to Capacitor.
 - Understanding Cordova vs Capacitor differences
 - Finding Capacitor equivalents for Cordova plugins
 - Modernizing hybrid mobile apps
+
+## Live Project Snapshot
+
+Current migration-related packages:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.includes('cordova')||name.startsWith('@capacitor/')||name.startsWith('@ionic-enterprise/'))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
+
+Relevant config and platform paths:
+!`find . -maxdepth 3 \( -name 'config.xml' -o -name 'capacitor.config.json' -o -name 'capacitor.config.ts' -o -name 'capacitor.config.js' -o -path './ios' -o -path './android' \)`
 
 ## Why Migrate from Cordova?
 
@@ -30,6 +41,8 @@ Step-by-step guide for migrating from Apache Cordova/PhoneGap to Capacitor.
 ## Migration Process Overview
 
 ### Step 1: Assess Your Current App
+
+Start from the injected snapshot above before falling back to manual inspection.
 
 **Check Cordova version:**
 ```bash

--- a/skills/framework-to-capacitor/SKILL.md
+++ b/skills/framework-to-capacitor/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: framework-to-capacitor
 description: Guide for integrating modern web frameworks with Capacitor. Covers Next.js static export, React, Vue, Angular, Svelte, and others. Use this skill when converting framework apps to mobile apps with Capacitor.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Framework to Capacitor Integration
@@ -14,6 +17,14 @@ Comprehensive guide for integrating web frameworks with Capacitor to build mobil
 - Configuring static exports for Capacitor
 - Setting up routing for mobile apps
 - Optimizing framework builds for native platforms
+
+## Live Project Snapshot
+
+Detected framework and build dependencies:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const matchers=['next','react','vue','@angular/core','@sveltejs/kit','@builder.io/qwik','@remix-run/react','solid-js','vite','@capacitor/core','@capacitor/cli'];const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(matchers.includes(name))out.push(section+'.'+name+'='+version)}}for(const [name,cmd] of Object.entries(pkg.scripts||{})){if(['build','export','sync','cap:sync'].includes(name))out.push('scripts.'+name+'='+cmd)}console.log(out.join('\n'))"`
+
+Relevant framework and Capacitor config paths:
+!`find . -maxdepth 3 \( -name 'next.config.js' -o -name 'next.config.mjs' -o -name 'vite.config.ts' -o -name 'vite.config.js' -o -name 'angular.json' -o -name 'svelte.config.js' -o -name 'capacitor.config.json' -o -name 'capacitor.config.ts' -o -name 'capacitor.config.js' \)`
 
 ## Framework Support Matrix
 

--- a/skills/ionic-appflow-migration/SKILL.md
+++ b/skills/ionic-appflow-migration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ionic-appflow-migration
 description: Guides the agent through migrating an existing Ionic or Capacitor project away from Ionic Appflow. Use when detecting Appflow live updates, cloud builds, or store deployment flows and replacing them with Capgo live updates plus the repository's CI/CD and store publishing setup. Do not use for Ionic Enterprise SDK plugin migration or for setting up a fresh Capacitor project from scratch.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(find *)
 ---
 
 # Ionic Appflow Migration
@@ -12,6 +15,14 @@ Migrate an existing Ionic or Capacitor project away from Ionic Appflow.
 - User is moving off Ionic Appflow
 - The project uses Appflow Live Updates, cloud builds, or store deployment
 - The repository still references `ionic appflow`, `@capacitor/live-updates`, or `cordova-plugin-ionic`
+
+## Live Project Snapshot
+
+Detected Appflow-related packages and scripts:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name==='@capacitor/live-updates'||name==='cordova-plugin-ionic'||name.includes('appflow'))out.push(section+'.'+name+'='+version)}}for(const [name,cmd] of Object.entries(pkg.scripts||{})){if(/appflow|ionic cloud|ionic package|live-updates/i.test(cmd))out.push('scripts.'+name+'='+cmd)}console.log(out.join('\n'))"`
+
+Possible Appflow config and workflow paths:
+!`find . -maxdepth 4 \( -name '.io-config.json' -o -name 'ionic.config.json' -o -name 'capacitor.config.json' -o -name 'capacitor.config.ts' -o -name 'capacitor.config.js' -o -path './.github/workflows' \)`
 
 ## Migration Strategy
 
@@ -26,6 +37,8 @@ Use this skill to detect what Appflow is doing today, then hand off each feature
 ## Procedures
 
 ### Step 1: Detect Appflow Usage
+
+Start from the injected snapshot above, then search more broadly if the migration surface is still unclear.
 
 Search the repository for:
 

--- a/skills/ionic-enterprise-sdk-migration/SKILL.md
+++ b/skills/ionic-enterprise-sdk-migration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ionic-enterprise-sdk-migration
 description: Guides the agent through migrating Capacitor apps from Ionic Enterprise SDK plugins to Capgo and Capacitor alternatives. Covers dependency detection, API replacement, local storage changes, and platform cleanup. Do not use for generic Capacitor version upgrades or Capgo live updates.
+allowed-tools:
+  - Bash(node -e *)
+  - Bash(rg *)
 ---
 
 # Ionic Enterprise SDK Migration
@@ -12,6 +15,11 @@ Migrate Capacitor apps away from Ionic Enterprise SDK plugins and onto open alte
 - User is replacing `@ionic-enterprise/*` plugins
 - User wants to remove Ionic Enterprise dependencies from an app
 - User needs a migration path for auth, biometric unlock, or secure local storage
+
+## Live Project Snapshot
+
+Detected Ionic Enterprise and replacement packages:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(name.startsWith('@ionic-enterprise/')||name.startsWith('@capgo/')||name==='@capacitor/preferences')out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
 
 ## Replacement Map
 
@@ -33,7 +41,7 @@ If the app only needs non-sensitive key-value storage, use `@capacitor/preferenc
 
 ### Step 1: Detect Ionic Enterprise Dependencies
 
-Read `package.json` and look for:
+Start from the injected package snapshot, then read `package.json` directly and look for:
 
 - `@ionic-enterprise/auth`
 - `@ionic-enterprise/identity-vault`

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -36,6 +36,12 @@ Command the agent to read supporting files only when the current step needs them
 
 Prefer one-level-deep support files with explicit relative paths.
 
+When a skill depends on repository state that will differ at invocation time, prefer a guarded inline shell snapshot such as ``!`node -e "..."` `` instead of baking the current state into prose.
+
+Only do this when the command materially improves the invoked prompt, and keep the output short and deterministic.
+
+If a skill uses inline commands, declare the minimum required `allowed-tools` entries in frontmatter and keep them read-only.
+
 ### Step 4: Add Validation
 
 Create a `skillgrade` eval when the skill needs regression testing.
@@ -53,3 +59,4 @@ Replace ambiguous prose with concrete commands, file names, or output expectatio
 - If a skill cannot be validated, reduce scope until the missing behavior becomes testable.
 - If the description is too broad, tighten the trigger text before adding more instructions.
 - If the supporting material grows too large, extract it into a separate file and point the agent to it explicitly.
+- If an inline command would require broad shell access or produce noisy output, keep the skill static and tell the agent to inspect the files explicitly instead.

--- a/skills/sqlite-to-fast-sql/SKILL.md
+++ b/skills/sqlite-to-fast-sql/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sqlite-to-fast-sql
 description: Guides the agent through migrating SQLite and SQL-style Capacitor plugins to @capgo/capacitor-fast-sql. Use when replacing bridge-based SQL plugins, adding encryption, preserving transactions, or moving key-value storage onto Fast SQL. Do not use for non-SQL storage, generic app upgrades, or plugins that already wrap Fast SQL.
+allowed-tools:
+  - Bash(node -e *)
 ---
 
 # SQLite to Fast SQL Migration
@@ -13,6 +15,11 @@ Migrate bridge-based SQLite or SQL plugins to `@capgo/capacitor-fast-sql`.
 - User needs better performance for large result sets or sync-style writes
 - User wants encrypted local storage, transactions, batch writes, or BLOB support
 - User wants a key-value wrapper backed by Fast SQL instead of a legacy storage plugin
+
+## Live Project Snapshot
+
+Detected SQL-related packages:
+!`node -e "const fs=require('fs');if(!fs.existsSync('package.json'))process.exit(0);const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));const needles=['sqlite','sqlcipher','typeorm','watermelondb','pouchdb','@capacitor-community/sqlite','@capawesome-team/capacitor-sqlite','@capgo/capacitor-fast-sql'];const out=[];for(const section of ['dependencies','devDependencies']){for(const [name,version] of Object.entries(pkg[section]||{})){if(needles.some((needle)=>name.includes(needle)))out.push(section+'.'+name+'='+version)}}console.log(out.sort().join('\n'))"`
 
 ## Why Fast SQL
 
@@ -31,7 +38,7 @@ Fast SQL also provides:
 
 ### Step 1: Inspect the Current SQL Plugin
 
-Read `package.json` and identify the current SQL plugin(s).
+Start from the injected package snapshot, then read `package.json` directly if the current SQL plugin set still needs clarification.
 
 Document whether the app uses:
 


### PR DESCRIPTION
## What
- add guidance in `skill-creator` for using inline shell snapshots with minimal `allowed-tools`
- add read-only `allowed-tools` frontmatter to repo-aware upgrade and migration skills
- inject short runtime snapshots for Capacitor versions, plugin state, framework detection, and migration-relevant dependencies
- add a new `capacitor-apple-review-preflight` skill for Apple review audits on Capacitor apps
- vendor the upstream Apple guideline and rejection-rule references from `truongduy2611/app-store-preflight-skills` and wrap them with Capacitor-specific routing
- route Apple rejection and preflight audit requests away from the broader `capacitor-app-store` publishing skill

## Why
- these skills currently tell the agent to inspect local project state, but they do not preload that state into the invoked prompt
- inline command snapshots make the skills more context-aware without hardcoding stale repository facts
- Apple review and rejection diagnosis is a distinct workflow from generic store publishing, and it benefits from a dedicated skill

## How
- use guarded `node -e` snippets to read `package.json` only when it exists and print compact summaries
- use small `find` snapshots where path discovery is helpful for migration or upgrade workflows
- create a new Capacitor-focused Apple preflight skill with vendored guideline and rule references plus Capacitor/iOS inspection steps
- update `README.md`, `package.json`, and `capacitor-app-store` routing text to expose the new skill

## Testing
- ran `bun run lint-skills` after the inline-snapshot edits
- reran `bun run lint-skills` after rebasing the branch onto `origin/main`
- ran `bun run lint-skills` again after adding the Apple review preflight skill and its references

## Not Tested
- did not run skillgrade evals because no provider API key was configured for this session
- did not execute the inline commands through Claude Code itself in this repository
- did not run the upstream preflight flow end-to-end against a real Capacitor app with `asc` metadata access