### PR TITLE
[codex] Upgrade Capgo native builds skill

### DIFF
--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -96,7 +96,7 @@ Use manual credential commands instead when the user already has certificates, p
 Use this when the user already has Apple signing files:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --certificate ./cert.p12 --p12-password "P12_PASSWORD" \
   --ios-provisioning-profile ./profile.mobileprovision \
   --apple-key ./AuthKey_KEYID.p8 --apple-key-id "KEY_ID" \
@@ -106,7 +106,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 For apps with extensions or multiple targets, repeat `--ios-provisioning-profile` and map each bundle ID:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --ios-provisioning-profile com.example.app=./App.mobileprovision \
   --ios-provisioning-profile com.example.app.widget=./Widget.mobileprovision
 ```
@@ -114,7 +114,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 For ad-hoc iOS builds, set the distribution mode and collect the IPA with `--output-upload`:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --ios-distribution ad_hoc \
   --certificate ./cert.p12 \
   --ios-provisioning-profile ./adhoc.mobileprovision \
@@ -126,7 +126,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 Use this when the user already has Android signing files:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform android \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform android \
   --keystore ./release.jks --keystore-alias "release-key" \
   --keystore-key-password "KEY_PASSWORD" \
   --keystore-store-password "STORE_PASSWORD" \
@@ -136,7 +136,7 @@ npx @capgo/cli@latest build credentials save --platform android \
 If the user only needs an APK/AAB download link and not Play upload, save `--output-upload` and omit or override Play upload:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform android \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform android \
   --keystore ./release.jks --keystore-alias "release-key" \
   --keystore-key-password "KEY_PASSWORD" \
   --keystore-store-password "STORE_PASSWORD" \
@@ -204,10 +204,10 @@ npx @capgo/cli@latest build credentials list --local
 Update only changed fields:
 
 ```bash
-npx @capgo/cli@latest build credentials update --platform ios \
+npx @capgo/cli@latest build credentials update --appId com.example.app --platform ios \
   --ios-provisioning-profile ./new-profile.mobileprovision
 
-npx @capgo/cli@latest build credentials update --platform android \
+npx @capgo/cli@latest build credentials update --appId com.example.app --platform android \
   --keystore ./new-release.jks
 ```
 
@@ -219,7 +219,7 @@ For iOS provisioning profile updates:
 Migrate legacy iOS provisioning credentials:
 
 ```bash
-npx @capgo/cli@latest build credentials migrate --platform ios
+npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios
 ```
 
 Clear credentials only when the user wants removal:
@@ -263,7 +263,7 @@ Use repository or CI secret storage. Do not commit signing files or generated cr
 - Missing output destination: add store upload credentials or enable `--output-upload`.
 - No download link: request or save credentials with `--output-upload` and set `--output-retention` if the default TTL is too short.
 - iOS signing failure: verify certificate password, Apple Team ID, distribution mode, and every bundle ID to provisioning profile mapping.
-- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --platform ios`.
+- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios`.
 - Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
 - Play upload should be skipped: use `--output-upload --no-playstore-upload`.
 - Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.

--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -1,64 +1,279 @@
 ---
 name: capgo-native-builds
-description: Guides the agent through Capgo native cloud build workflows for iOS and Android. Use when requesting a native build, configuring build credentials, updating signing material, or controlling build output upload behavior. Do not use for OTA bundle uploads or generic CI setup without Capgo builds.
+description: Use for Capgo Cloud Build native iOS and Android workflows, including CLI login, API-key handling, iOS build onboarding, signing credential storage, build requests, store upload settings, output download links, and troubleshooting. Do not use for OTA bundle uploads or generic Capacitor setup unless a native Capgo build is requested.
 ---
 
 # Capgo Native Builds
 
-Use Capgo native builds for iOS and Android cloud build requests.
+Use this skill when the user wants Capgo to build native iOS or Android binaries in the cloud.
 
 ## When to Use This Skill
 
-- User wants a hosted native iOS or Android build
-- User needs Capgo build credentials configured or updated
-- User needs signed build artifacts and temporary output download links
+- The user asks for a Capgo Cloud Build, native build, signed IPA/APK/AAB, TestFlight/App Store build, Play Store build, or temporary build download link.
+- The user needs Capgo CLI login, build API-key setup, or help choosing between `login`, `CAPGO_TOKEN`, and `-a, --apikey`.
+- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or credential rotation.
+- The user asks about `build init`, `build request`, `build credentials save`, `build credentials update`, `build credentials list`, `build credentials clear`, or `build credentials migrate`.
 
-## Procedures
+Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setup, or local native builds that do not involve Capgo Cloud Build.
 
-### Step 1: Prepare Credentials
+## Operating Rules
 
-Before requesting a build, save credentials locally with the Capgo CLI.
+- Use `npx @capgo/cli@latest` in user-facing commands.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
+- Prefer Capgo CLI build flows before inventing custom CI scripts.
+- Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
+- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process.
 
-Use the credential workflow that matches the platform:
+## First Checks
 
-- iOS -> certificate, provisioning profiles, App Store Connect credentials
-- Android -> keystore and Play config
+Before requesting a build, verify:
 
-### Step 2: Request the Build
+- The project is a Capacitor app and has the native folder for the target platform (`ios/` or `android/`).
+- The Capgo app exists. If needed, add it first:
 
-Prefer the Capgo build flow:
+```bash
+npx @capgo/cli@latest app add com.example.app
+```
+
+- The user has a Capgo API key with permission to trigger native builds for the app.
+- Signing credentials exist or the workflow will create/save them before `build request`.
+- The output destination is clear:
+  - Store upload: provide App Store Connect credentials for iOS or Play config for Android.
+  - Download link only: use `--output-upload`, optionally with `--output-retention <duration>`.
+
+## Authentication and Login
+
+Use `login` when the machine should remember the Capgo API key:
+
+```bash
+npx @capgo/cli@latest login
+npx @capgo/cli@latest login YOUR_API_KEY
+npx @capgo/cli@latest login --local YOUR_API_KEY
+```
+
+Authentication precedence for build commands:
+
+1. `-a, --apikey <apikey>` on the command.
+2. `CAPGO_TOKEN` environment variable.
+3. Global key saved by `login` in `~/.capgo`.
+4. Local key saved by `login --local` in `.capgo`.
+
+Use `CAPGO_TOKEN` for CI secrets. Use `-a, --apikey` when creating a single copy-pasteable command for onboarding or support. Use `login --local` only when the key should stay scoped to this repository; verify `.capgo` is ignored by git.
+
+## Recommended Build Flows
+
+### iOS Fast Path: `build init`
+
+For a first iOS cloud build, prefer the interactive onboarding command:
+
+```bash
+npx @capgo/cli@latest build init
+```
+
+If no key is saved, pass one explicitly:
+
+```bash
+npx @capgo/cli@latest build init -a YOUR_API_KEY
+```
+
+`build init` also has the alias `build onboarding`. It is best when the user wants the CLI to create and save iOS signing material with the fewest manual steps.
+
+What it handles:
+
+- Verifies the App Store Connect API key.
+- Creates or reuses Apple signing assets where possible.
+- Registers or reuses the bundle ID.
+- Creates App Store provisioning profiles.
+- Saves build credentials into the same local store used by `build request`.
+- Can request the first cloud build at the end.
+- Persists onboarding progress under `~/.capgo-credentials/onboarding/` so the user can resume.
+- Saves recovery/support material under `~/.capgo-credentials/support/` after unexpected failures.
+
+Use manual credential commands instead when the user already has certificates, profiles, or CI secrets prepared.
+
+### Manual iOS Credential Save
+
+Use this when the user already has Apple signing files:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --certificate ./cert.p12 --p12-password "P12_PASSWORD" \
+  --ios-provisioning-profile ./profile.mobileprovision \
+  --apple-key ./AuthKey_KEYID.p8 --apple-key-id "KEY_ID" \
+  --apple-issuer-id "ISSUER_UUID" --apple-team-id "TEAM_ID"
+```
+
+For apps with extensions or multiple targets, repeat `--ios-provisioning-profile` and map each bundle ID:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --ios-provisioning-profile com.example.app=./App.mobileprovision \
+  --ios-provisioning-profile com.example.app.widget=./Widget.mobileprovision
+```
+
+For ad-hoc iOS builds, set the distribution mode and collect the IPA with `--output-upload`:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --ios-distribution ad_hoc \
+  --certificate ./cert.p12 \
+  --ios-provisioning-profile ./adhoc.mobileprovision \
+  --output-upload
+```
+
+### Manual Android Credential Save
+
+Use this when the user already has Android signing files:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform android \
+  --keystore ./release.jks --keystore-alias "release-key" \
+  --keystore-key-password "KEY_PASSWORD" \
+  --keystore-store-password "STORE_PASSWORD" \
+  --play-config ./service-account.json
+```
+
+If the user only needs an APK/AAB download link and not Play upload, save `--output-upload` and omit or override Play upload:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform android \
+  --keystore ./release.jks --keystore-alias "release-key" \
+  --keystore-key-password "KEY_PASSWORD" \
+  --keystore-store-password "STORE_PASSWORD" \
+  --output-upload
+```
+
+Use `--android-flavor <flavor>` when the Android project has multiple product flavors.
+
+### Request a Build
+
+Use `build request [appId]` after login and credentials are ready:
 
 ```bash
 npx @capgo/cli@latest build request com.example.app --platform ios --path .
+npx @capgo/cli@latest build request com.example.app --platform android --path .
 ```
 
-Use `--platform android` for Android builds.
+Useful request options:
 
-Add `--output-upload` when the user needs a time-limited download link for the build output.
+- `--platform ios|android`: required.
+- `--path <path>`: project directory, default is the current directory.
+- `--node-modules <paths>`: comma-separated `node_modules` paths for monorepos.
+- `--build-mode debug|release`: defaults to release.
+- `--ios-scheme <scheme>` and `--ios-target <target>` for custom Xcode projects.
+- `--ios-distribution app_store|ad_hoc`.
+- `--android-flavor <flavor>` for Android product flavors.
+- `--output-upload` to create temporary IPA/APK/AAB download links.
+- `--output-retention <duration>` from `1h` to `7d`.
+- `--no-playstore-upload` to skip Play upload for an Android build. This requires `--output-upload`.
+- `--skip-build-number-bump` when the project owns native build numbers itself.
+- `--verbose` for support/debugging.
 
-### Step 3: Adjust Build Inputs
+Example: collect an iOS ad-hoc IPA link:
 
-Handle platform-specific build inputs as needed:
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform ios \
+  --ios-distribution ad_hoc \
+  --output-upload \
+  --output-retention 2d
+```
 
-- iOS scheme, target, distribution mode, provisioning profile mapping
-- Android flavor, keystore alias, Play config
+Example: Android flavor with a download link instead of Play upload:
 
-Only add flags that the project actually needs.
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform android \
+  --android-flavor production \
+  --output-upload \
+  --no-playstore-upload
+```
 
-### Step 4: Manage Credentials
+## Credential Management
 
-Use the Capgo CLI credential commands for updates:
+Build credentials are stored globally in `~/.capgo-credentials/credentials.json` by default. Add `--local` to use `.capgo-credentials.json` in the project root. Never commit either credentials file.
 
-- `build credentials save`
-- `build credentials list`
-- `build credentials update`
-- `build credentials clear`
-- `build credentials migrate`
+List masked saved credentials:
 
-Keep credentials local unless the user explicitly wants project-local storage.
+```bash
+npx @capgo/cli@latest build credentials list
+npx @capgo/cli@latest build credentials list --appId com.example.app
+npx @capgo/cli@latest build credentials list --local
+```
 
-## Error Handling
+Update only changed fields:
 
-- For iOS signing failures, re-check certificate, provisioning mapping, and App Store Connect fields before retrying the build.
-- For Android signing failures, re-check the keystore path, alias, and passwords before changing build logic.
-- For missing output artifacts, verify `--output-upload` and retention settings first.
+```bash
+npx @capgo/cli@latest build credentials update --platform ios \
+  --ios-provisioning-profile ./new-profile.mobileprovision
+
+npx @capgo/cli@latest build credentials update --platform android \
+  --keystore ./new-release.jks
+```
+
+For iOS provisioning profile updates:
+
+- By default, new `--ios-provisioning-profile` entries are merged into the existing map.
+- Use `--overwrite-ios-provisioning-map` only when replacing the whole mapping intentionally.
+
+Migrate legacy iOS provisioning credentials:
+
+```bash
+npx @capgo/cli@latest build credentials migrate --platform ios
+```
+
+Clear credentials only when the user wants removal:
+
+```bash
+npx @capgo/cli@latest build credentials clear --appId com.example.app --platform ios
+npx @capgo/cli@latest build credentials clear --local
+```
+
+## CI Guidance
+
+For CI, prefer secrets in environment variables instead of local credential files:
+
+```bash
+CAPGO_TOKEN=YOUR_CAPGO_TOKEN \
+BUILD_CERTIFICATE_BASE64=BASE64_P12 \
+P12_PASSWORD=P12_PASSWORD \
+APPLE_KEY_ID=KEY_ID \
+APPLE_ISSUER_ID=ISSUER_UUID \
+APPLE_KEY_CONTENT=BASE64_P8 \
+APP_STORE_CONNECT_TEAM_ID=TEAM_ID \
+CAPGO_IOS_PROVISIONING_MAP=PROVISIONING_MAP_JSON \
+npx @capgo/cli@latest build request com.example.app --platform ios
+```
+
+Android CI commonly uses:
+
+- `CAPGO_TOKEN`
+- `ANDROID_KEYSTORE_FILE`
+- `KEYSTORE_KEY_ALIAS`
+- `KEYSTORE_KEY_PASSWORD`
+- `KEYSTORE_STORE_PASSWORD`
+- `PLAY_CONFIG_JSON` or `--output-upload`
+
+Use repository or CI secret storage. Do not commit signing files or generated credential JSON.
+
+## Troubleshooting
+
+- `No Capgo API key found`: run `npx @capgo/cli@latest login`, set `CAPGO_TOKEN`, or pass `-a YOUR_API_KEY`.
+- `Insufficient permissions`: verify the API key can access the app and includes native build permission.
+- Missing output destination: add store upload credentials or enable `--output-upload`.
+- No download link: request or save credentials with `--output-upload` and set `--output-retention` if the default TTL is too short.
+- iOS signing failure: verify certificate password, Apple Team ID, distribution mode, and every bundle ID to provisioning profile mapping.
+- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --platform ios`.
+- Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
+- Play upload should be skipped: use `--output-upload --no-playstore-upload`.
+- Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.
+- Need support evidence: rerun the failing command with `--verbose`.
+
+## Supporting Docs
+
+- Build command reference: `https://capgo.app/docs/cli/reference/build/`
+- Login command reference: `https://capgo.app/docs/cli/reference/login/`
+- Cloud Build getting started: `https://capgo.app/docs/cli/cloud-build/getting-started/`
+- iOS build setup: `https://capgo.app/docs/cli/cloud-build/ios/`
+- Android build setup: `https://capgo.app/docs/cli/cloud-build/android/`
+- Credential management: `https://capgo.app/docs/cli/cloud-build/credentials/`

--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -55,8 +55,8 @@ Authentication precedence for build commands:
 
 1. `-a, --apikey <apikey>` on the command.
 2. `CAPGO_TOKEN` environment variable.
-3. Global key saved by `login` in `~/.capgo`.
-4. Local key saved by `login --local` in `.capgo`.
+3. Local key saved by `login --local` in `.capgo`.
+4. Global key saved by `login` in `~/.capgo`.
 
 Use `CAPGO_TOKEN` for CI secrets. Use `-a, --apikey` when creating a single copy-pasteable command for onboarding or support. Use `login --local` only when the key should stay scoped to this repository; verify `.capgo` is ignored by git.
 

--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -22,7 +22,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 - Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
-- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process.
+- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).
 
 ## First Checks
 
@@ -158,7 +158,6 @@ Useful request options:
 
 - `--platform ios|android`: required.
 - `--path <path>`: project directory, default is the current directory.
-- `--node-modules <paths>`: comma-separated `node_modules` paths for monorepos.
 - `--build-mode debug|release`: defaults to release.
 - `--ios-scheme <scheme>` and `--ios-target <target>` for custom Xcode projects.
 - `--ios-distribution app_store|ad_hoc`.
@@ -266,7 +265,7 @@ Use repository or CI secret storage. Do not commit signing files or generated cr
 - Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios`.
 - Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
 - Play upload should be skipped: use `--output-upload --no-playstore-upload`.
-- Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.
+- Monorepo path mismatch: pass the app-specific `--path` value and run from the app root when possible.
 - Need support evidence: rerun the failing command with `--verbose`.
 
 ## Supporting Docs

--- a/plugins/capgo-cloud/skills/capgo-native-builds/metadata.json
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/metadata.json
@@ -1,17 +1,25 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "organization": "Capgo",
-  "date": "March 2026",
-  "abstract": "Guide for Capgo native cloud build requests, credential management, and build output configuration.",
+  "date": "May 2026",
+  "abstract": "Guide for Capgo Cloud Build login, native iOS and Android build onboarding, signing credential management, build requests, output upload links, CI secrets, and troubleshooting.",
   "triggers": [
     "capgo build",
+    "capgo build init",
+    "capgo login build",
     "native build",
     "cloud build ios",
     "cloud build android",
+    "build credentials",
+    "output upload",
     "capgo native build"
   ],
   "references": [
+    "https://capgo.app/docs/cli/reference/build/",
+    "https://capgo.app/docs/cli/reference/login/",
+    "https://capgo.app/docs/cli/cloud-build/getting-started/",
     "https://capgo.app/docs/cli/cloud-build/ios/",
-    "https://capgo.app/docs/cli/cloud-build/android/"
+    "https://capgo.app/docs/cli/cloud-build/android/",
+    "https://capgo.app/docs/cli/cloud-build/credentials/"
   ]
 }

--- a/scripts/lint-skills.mjs
+++ b/scripts/lint-skills.mjs
@@ -186,15 +186,15 @@ async function validateMirroredSkills(errors) {
     let mirror;
     try {
       [canonical, mirror] = await Promise.all([
-        readFile(canonicalPath, 'utf8'),
-        readFile(mirrorPath, 'utf8'),
+        readFile(canonicalPath),
+        readFile(mirrorPath),
       ]);
     } catch {
       errors.push(`mirrored skills: ${mirrorRelative} must exist and mirror ${canonicalRelative}`);
       continue;
     }
 
-    if (canonical !== mirror) {
+    if (!canonical.equals(mirror)) {
       errors.push(`mirrored skills: ${mirrorRelative} must match ${canonicalRelative} byte-for-byte`);
     }
   }

--- a/scripts/lint-skills.mjs
+++ b/scripts/lint-skills.mjs
@@ -166,6 +166,40 @@ async function validateClaudeMarketplace(skillDirs, errors) {
   }
 }
 
+async function validateMirroredSkills(errors) {
+  const mirroredFiles = [
+    [
+      'skills/capgo-native-builds/SKILL.md',
+      'plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md',
+    ],
+    [
+      'skills/capgo-native-builds/metadata.json',
+      'plugins/capgo-cloud/skills/capgo-native-builds/metadata.json',
+    ],
+  ];
+
+  for (const [canonicalRelative, mirrorRelative] of mirroredFiles) {
+    const canonicalPath = path.join(root, canonicalRelative);
+    const mirrorPath = path.join(root, mirrorRelative);
+
+    let canonical;
+    let mirror;
+    try {
+      [canonical, mirror] = await Promise.all([
+        readFile(canonicalPath, 'utf8'),
+        readFile(mirrorPath, 'utf8'),
+      ]);
+    } catch {
+      errors.push(`mirrored skills: ${mirrorRelative} must exist and mirror ${canonicalRelative}`);
+      continue;
+    }
+
+    if (canonical !== mirror) {
+      errors.push(`mirrored skills: ${mirrorRelative} must match ${canonicalRelative} byte-for-byte`);
+    }
+  }
+}
+
 async function main() {
   const entries = await readdir(skillsDir, { withFileTypes: true });
   const skillDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
@@ -215,6 +249,7 @@ async function main() {
   }
 
   await validateClaudeMarketplace(skillDirs, errors);
+  await validateMirroredSkills(errors);
 
   if (errors.length > 0) {
     console.error('Skill lint failed:');

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -96,7 +96,7 @@ Use manual credential commands instead when the user already has certificates, p
 Use this when the user already has Apple signing files:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --certificate ./cert.p12 --p12-password "P12_PASSWORD" \
   --ios-provisioning-profile ./profile.mobileprovision \
   --apple-key ./AuthKey_KEYID.p8 --apple-key-id "KEY_ID" \
@@ -106,7 +106,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 For apps with extensions or multiple targets, repeat `--ios-provisioning-profile` and map each bundle ID:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --ios-provisioning-profile com.example.app=./App.mobileprovision \
   --ios-provisioning-profile com.example.app.widget=./Widget.mobileprovision
 ```
@@ -114,7 +114,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 For ad-hoc iOS builds, set the distribution mode and collect the IPA with `--output-upload`:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform ios \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform ios \
   --ios-distribution ad_hoc \
   --certificate ./cert.p12 \
   --ios-provisioning-profile ./adhoc.mobileprovision \
@@ -126,7 +126,7 @@ npx @capgo/cli@latest build credentials save --platform ios \
 Use this when the user already has Android signing files:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform android \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform android \
   --keystore ./release.jks --keystore-alias "release-key" \
   --keystore-key-password "KEY_PASSWORD" \
   --keystore-store-password "STORE_PASSWORD" \
@@ -136,7 +136,7 @@ npx @capgo/cli@latest build credentials save --platform android \
 If the user only needs an APK/AAB download link and not Play upload, save `--output-upload` and omit or override Play upload:
 
 ```bash
-npx @capgo/cli@latest build credentials save --platform android \
+npx @capgo/cli@latest build credentials save --appId com.example.app --platform android \
   --keystore ./release.jks --keystore-alias "release-key" \
   --keystore-key-password "KEY_PASSWORD" \
   --keystore-store-password "STORE_PASSWORD" \
@@ -204,10 +204,10 @@ npx @capgo/cli@latest build credentials list --local
 Update only changed fields:
 
 ```bash
-npx @capgo/cli@latest build credentials update --platform ios \
+npx @capgo/cli@latest build credentials update --appId com.example.app --platform ios \
   --ios-provisioning-profile ./new-profile.mobileprovision
 
-npx @capgo/cli@latest build credentials update --platform android \
+npx @capgo/cli@latest build credentials update --appId com.example.app --platform android \
   --keystore ./new-release.jks
 ```
 
@@ -219,7 +219,7 @@ For iOS provisioning profile updates:
 Migrate legacy iOS provisioning credentials:
 
 ```bash
-npx @capgo/cli@latest build credentials migrate --platform ios
+npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios
 ```
 
 Clear credentials only when the user wants removal:
@@ -263,7 +263,7 @@ Use repository or CI secret storage. Do not commit signing files or generated cr
 - Missing output destination: add store upload credentials or enable `--output-upload`.
 - No download link: request or save credentials with `--output-upload` and set `--output-retention` if the default TTL is too short.
 - iOS signing failure: verify certificate password, Apple Team ID, distribution mode, and every bundle ID to provisioning profile mapping.
-- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --platform ios`.
+- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios`.
 - Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
 - Play upload should be skipped: use `--output-upload --no-playstore-upload`.
 - Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -1,64 +1,279 @@
 ---
 name: capgo-native-builds
-description: Guides the agent through Capgo native cloud build workflows for iOS and Android. Use when requesting a native build, configuring build credentials, updating signing material, or controlling build output upload behavior. Do not use for OTA bundle uploads or generic CI setup without Capgo builds.
+description: Use for Capgo Cloud Build native iOS and Android workflows, including CLI login, API-key handling, iOS build onboarding, signing credential storage, build requests, store upload settings, output download links, and troubleshooting. Do not use for OTA bundle uploads or generic Capacitor setup unless a native Capgo build is requested.
 ---
 
 # Capgo Native Builds
 
-Use Capgo native builds for iOS and Android cloud build requests.
+Use this skill when the user wants Capgo to build native iOS or Android binaries in the cloud.
 
 ## When to Use This Skill
 
-- User wants a hosted native iOS or Android build
-- User needs Capgo build credentials configured or updated
-- User needs signed build artifacts and temporary output download links
+- The user asks for a Capgo Cloud Build, native build, signed IPA/APK/AAB, TestFlight/App Store build, Play Store build, or temporary build download link.
+- The user needs Capgo CLI login, build API-key setup, or help choosing between `login`, `CAPGO_TOKEN`, and `-a, --apikey`.
+- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or credential rotation.
+- The user asks about `build init`, `build request`, `build credentials save`, `build credentials update`, `build credentials list`, `build credentials clear`, or `build credentials migrate`.
 
-## Procedures
+Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setup, or local native builds that do not involve Capgo Cloud Build.
 
-### Step 1: Prepare Credentials
+## Operating Rules
 
-Before requesting a build, save credentials locally with the Capgo CLI.
+- Use `npx @capgo/cli@latest` in user-facing commands.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
+- Prefer Capgo CLI build flows before inventing custom CI scripts.
+- Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
+- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process.
 
-Use the credential workflow that matches the platform:
+## First Checks
 
-- iOS -> certificate, provisioning profiles, App Store Connect credentials
-- Android -> keystore and Play config
+Before requesting a build, verify:
 
-### Step 2: Request the Build
+- The project is a Capacitor app and has the native folder for the target platform (`ios/` or `android/`).
+- The Capgo app exists. If needed, add it first:
 
-Prefer the Capgo build flow:
+```bash
+npx @capgo/cli@latest app add com.example.app
+```
+
+- The user has a Capgo API key with permission to trigger native builds for the app.
+- Signing credentials exist or the workflow will create/save them before `build request`.
+- The output destination is clear:
+  - Store upload: provide App Store Connect credentials for iOS or Play config for Android.
+  - Download link only: use `--output-upload`, optionally with `--output-retention <duration>`.
+
+## Authentication and Login
+
+Use `login` when the machine should remember the Capgo API key:
+
+```bash
+npx @capgo/cli@latest login
+npx @capgo/cli@latest login YOUR_API_KEY
+npx @capgo/cli@latest login --local YOUR_API_KEY
+```
+
+Authentication precedence for build commands:
+
+1. `-a, --apikey <apikey>` on the command.
+2. `CAPGO_TOKEN` environment variable.
+3. Global key saved by `login` in `~/.capgo`.
+4. Local key saved by `login --local` in `.capgo`.
+
+Use `CAPGO_TOKEN` for CI secrets. Use `-a, --apikey` when creating a single copy-pasteable command for onboarding or support. Use `login --local` only when the key should stay scoped to this repository; verify `.capgo` is ignored by git.
+
+## Recommended Build Flows
+
+### iOS Fast Path: `build init`
+
+For a first iOS cloud build, prefer the interactive onboarding command:
+
+```bash
+npx @capgo/cli@latest build init
+```
+
+If no key is saved, pass one explicitly:
+
+```bash
+npx @capgo/cli@latest build init -a YOUR_API_KEY
+```
+
+`build init` also has the alias `build onboarding`. It is best when the user wants the CLI to create and save iOS signing material with the fewest manual steps.
+
+What it handles:
+
+- Verifies the App Store Connect API key.
+- Creates or reuses Apple signing assets where possible.
+- Registers or reuses the bundle ID.
+- Creates App Store provisioning profiles.
+- Saves build credentials into the same local store used by `build request`.
+- Can request the first cloud build at the end.
+- Persists onboarding progress under `~/.capgo-credentials/onboarding/` so the user can resume.
+- Saves recovery/support material under `~/.capgo-credentials/support/` after unexpected failures.
+
+Use manual credential commands instead when the user already has certificates, profiles, or CI secrets prepared.
+
+### Manual iOS Credential Save
+
+Use this when the user already has Apple signing files:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --certificate ./cert.p12 --p12-password "P12_PASSWORD" \
+  --ios-provisioning-profile ./profile.mobileprovision \
+  --apple-key ./AuthKey_KEYID.p8 --apple-key-id "KEY_ID" \
+  --apple-issuer-id "ISSUER_UUID" --apple-team-id "TEAM_ID"
+```
+
+For apps with extensions or multiple targets, repeat `--ios-provisioning-profile` and map each bundle ID:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --ios-provisioning-profile com.example.app=./App.mobileprovision \
+  --ios-provisioning-profile com.example.app.widget=./Widget.mobileprovision
+```
+
+For ad-hoc iOS builds, set the distribution mode and collect the IPA with `--output-upload`:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform ios \
+  --ios-distribution ad_hoc \
+  --certificate ./cert.p12 \
+  --ios-provisioning-profile ./adhoc.mobileprovision \
+  --output-upload
+```
+
+### Manual Android Credential Save
+
+Use this when the user already has Android signing files:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform android \
+  --keystore ./release.jks --keystore-alias "release-key" \
+  --keystore-key-password "KEY_PASSWORD" \
+  --keystore-store-password "STORE_PASSWORD" \
+  --play-config ./service-account.json
+```
+
+If the user only needs an APK/AAB download link and not Play upload, save `--output-upload` and omit or override Play upload:
+
+```bash
+npx @capgo/cli@latest build credentials save --platform android \
+  --keystore ./release.jks --keystore-alias "release-key" \
+  --keystore-key-password "KEY_PASSWORD" \
+  --keystore-store-password "STORE_PASSWORD" \
+  --output-upload
+```
+
+Use `--android-flavor <flavor>` when the Android project has multiple product flavors.
+
+### Request a Build
+
+Use `build request [appId]` after login and credentials are ready:
 
 ```bash
 npx @capgo/cli@latest build request com.example.app --platform ios --path .
+npx @capgo/cli@latest build request com.example.app --platform android --path .
 ```
 
-Use `--platform android` for Android builds.
+Useful request options:
 
-Add `--output-upload` when the user needs a time-limited download link for the build output.
+- `--platform ios|android`: required.
+- `--path <path>`: project directory, default is the current directory.
+- `--node-modules <paths>`: comma-separated `node_modules` paths for monorepos.
+- `--build-mode debug|release`: defaults to release.
+- `--ios-scheme <scheme>` and `--ios-target <target>` for custom Xcode projects.
+- `--ios-distribution app_store|ad_hoc`.
+- `--android-flavor <flavor>` for Android product flavors.
+- `--output-upload` to create temporary IPA/APK/AAB download links.
+- `--output-retention <duration>` from `1h` to `7d`.
+- `--no-playstore-upload` to skip Play upload for an Android build. This requires `--output-upload`.
+- `--skip-build-number-bump` when the project owns native build numbers itself.
+- `--verbose` for support/debugging.
 
-### Step 3: Adjust Build Inputs
+Example: collect an iOS ad-hoc IPA link:
 
-Handle platform-specific build inputs as needed:
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform ios \
+  --ios-distribution ad_hoc \
+  --output-upload \
+  --output-retention 2d
+```
 
-- iOS scheme, target, distribution mode, provisioning profile mapping
-- Android flavor, keystore alias, Play config
+Example: Android flavor with a download link instead of Play upload:
 
-Only add flags that the project actually needs.
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform android \
+  --android-flavor production \
+  --output-upload \
+  --no-playstore-upload
+```
 
-### Step 4: Manage Credentials
+## Credential Management
 
-Use the Capgo CLI credential commands for updates:
+Build credentials are stored globally in `~/.capgo-credentials/credentials.json` by default. Add `--local` to use `.capgo-credentials.json` in the project root. Never commit either credentials file.
 
-- `build credentials save`
-- `build credentials list`
-- `build credentials update`
-- `build credentials clear`
-- `build credentials migrate`
+List masked saved credentials:
 
-Keep credentials local unless the user explicitly wants project-local storage.
+```bash
+npx @capgo/cli@latest build credentials list
+npx @capgo/cli@latest build credentials list --appId com.example.app
+npx @capgo/cli@latest build credentials list --local
+```
 
-## Error Handling
+Update only changed fields:
 
-- For iOS signing failures, re-check certificate, provisioning mapping, and App Store Connect fields before retrying the build.
-- For Android signing failures, re-check the keystore path, alias, and passwords before changing build logic.
-- For missing output artifacts, verify `--output-upload` and retention settings first.
+```bash
+npx @capgo/cli@latest build credentials update --platform ios \
+  --ios-provisioning-profile ./new-profile.mobileprovision
+
+npx @capgo/cli@latest build credentials update --platform android \
+  --keystore ./new-release.jks
+```
+
+For iOS provisioning profile updates:
+
+- By default, new `--ios-provisioning-profile` entries are merged into the existing map.
+- Use `--overwrite-ios-provisioning-map` only when replacing the whole mapping intentionally.
+
+Migrate legacy iOS provisioning credentials:
+
+```bash
+npx @capgo/cli@latest build credentials migrate --platform ios
+```
+
+Clear credentials only when the user wants removal:
+
+```bash
+npx @capgo/cli@latest build credentials clear --appId com.example.app --platform ios
+npx @capgo/cli@latest build credentials clear --local
+```
+
+## CI Guidance
+
+For CI, prefer secrets in environment variables instead of local credential files:
+
+```bash
+CAPGO_TOKEN=YOUR_CAPGO_TOKEN \
+BUILD_CERTIFICATE_BASE64=BASE64_P12 \
+P12_PASSWORD=P12_PASSWORD \
+APPLE_KEY_ID=KEY_ID \
+APPLE_ISSUER_ID=ISSUER_UUID \
+APPLE_KEY_CONTENT=BASE64_P8 \
+APP_STORE_CONNECT_TEAM_ID=TEAM_ID \
+CAPGO_IOS_PROVISIONING_MAP=PROVISIONING_MAP_JSON \
+npx @capgo/cli@latest build request com.example.app --platform ios
+```
+
+Android CI commonly uses:
+
+- `CAPGO_TOKEN`
+- `ANDROID_KEYSTORE_FILE`
+- `KEYSTORE_KEY_ALIAS`
+- `KEYSTORE_KEY_PASSWORD`
+- `KEYSTORE_STORE_PASSWORD`
+- `PLAY_CONFIG_JSON` or `--output-upload`
+
+Use repository or CI secret storage. Do not commit signing files or generated credential JSON.
+
+## Troubleshooting
+
+- `No Capgo API key found`: run `npx @capgo/cli@latest login`, set `CAPGO_TOKEN`, or pass `-a YOUR_API_KEY`.
+- `Insufficient permissions`: verify the API key can access the app and includes native build permission.
+- Missing output destination: add store upload credentials or enable `--output-upload`.
+- No download link: request or save credentials with `--output-upload` and set `--output-retention` if the default TTL is too short.
+- iOS signing failure: verify certificate password, Apple Team ID, distribution mode, and every bundle ID to provisioning profile mapping.
+- Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --platform ios`.
+- Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
+- Play upload should be skipped: use `--output-upload --no-playstore-upload`.
+- Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.
+- Need support evidence: rerun the failing command with `--verbose`.
+
+## Supporting Docs
+
+- Build command reference: `https://capgo.app/docs/cli/reference/build/`
+- Login command reference: `https://capgo.app/docs/cli/reference/login/`
+- Cloud Build getting started: `https://capgo.app/docs/cli/cloud-build/getting-started/`
+- iOS build setup: `https://capgo.app/docs/cli/cloud-build/ios/`
+- Android build setup: `https://capgo.app/docs/cli/cloud-build/android/`
+- Credential management: `https://capgo.app/docs/cli/cloud-build/credentials/`

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -55,8 +55,8 @@ Authentication precedence for build commands:
 
 1. `-a, --apikey <apikey>` on the command.
 2. `CAPGO_TOKEN` environment variable.
-3. Global key saved by `login` in `~/.capgo`.
-4. Local key saved by `login --local` in `.capgo`.
+3. Local key saved by `login --local` in `.capgo`.
+4. Global key saved by `login` in `~/.capgo`.
 
 Use `CAPGO_TOKEN` for CI secrets. Use `-a, --apikey` when creating a single copy-pasteable command for onboarding or support. Use `login --local` only when the key should stay scoped to this repository; verify `.capgo` is ignored by git.
 

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -22,7 +22,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 - Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
-- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process.
+- Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).
 
 ## First Checks
 
@@ -158,7 +158,6 @@ Useful request options:
 
 - `--platform ios|android`: required.
 - `--path <path>`: project directory, default is the current directory.
-- `--node-modules <paths>`: comma-separated `node_modules` paths for monorepos.
 - `--build-mode debug|release`: defaults to release.
 - `--ios-scheme <scheme>` and `--ios-target <target>` for custom Xcode projects.
 - `--ios-distribution app_store|ad_hoc`.
@@ -266,7 +265,7 @@ Use repository or CI secret storage. Do not commit signing files or generated cr
 - Legacy iOS provisioning profile error: run `npx @capgo/cli@latest build credentials migrate --appId com.example.app --platform ios`.
 - Android signing failure: verify keystore path, alias, key password, store password, and product flavor.
 - Play upload should be skipped: use `--output-upload --no-playstore-upload`.
-- Monorepo dependency mismatch: pass the app-specific `--path` and `--node-modules` values.
+- Monorepo path mismatch: pass the app-specific `--path` value and run from the app root when possible.
 - Need support evidence: rerun the failing command with `--verbose`.
 
 ## Supporting Docs

--- a/skills/capgo-native-builds/metadata.json
+++ b/skills/capgo-native-builds/metadata.json
@@ -1,17 +1,25 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "organization": "Capgo",
-  "date": "March 2026",
-  "abstract": "Guide for Capgo native cloud build requests, credential management, and build output configuration.",
+  "date": "May 2026",
+  "abstract": "Guide for Capgo Cloud Build login, native iOS and Android build onboarding, signing credential management, build requests, output upload links, CI secrets, and troubleshooting.",
   "triggers": [
     "capgo build",
+    "capgo build init",
+    "capgo login build",
     "native build",
     "cloud build ios",
     "cloud build android",
+    "build credentials",
+    "output upload",
     "capgo native build"
   ],
   "references": [
+    "https://capgo.app/docs/cli/reference/build/",
+    "https://capgo.app/docs/cli/reference/login/",
+    "https://capgo.app/docs/cli/cloud-build/getting-started/",
     "https://capgo.app/docs/cli/cloud-build/ios/",
-    "https://capgo.app/docs/cli/cloud-build/android/"
+    "https://capgo.app/docs/cli/cloud-build/android/",
+    "https://capgo.app/docs/cli/cloud-build/credentials/"
   ]
 }


### PR DESCRIPTION
## What (AI generated)

- Expanded the Capgo Native Builds skill from a short command note into a full build workflow guide.
- Added login/API-key guidance, iOS `build init` onboarding, manual iOS and Android credential setup, build request examples, output upload behavior, CI secret guidance, and troubleshooting.
- Kept the root skill and Capgo Cloud plugin copy synchronized, including metadata and references.
- Added a lint-enforced mirror check for the Capgo Native Builds root/plugin skill copies.

## Why (AI generated)

- Agents need enough context to use Capgo Cloud Build correctly without guessing login, credential, signing, or output-link behavior.
- The existing skill did not cover the best path through the newer build system, especially `build init`, auth precedence, local credential storage, CI secrets, and store-vs-download output choices.
- The mirror check prevents future drift between the root skill and marketplace plugin copy.

## How (AI generated)

- Adapted the richer native-build guidance from the Capgo CLI command surface and current Capgo Cloud Build docs into the public skill format.
- Updated triggers, references, and the skill abstract so native-build, login, credential, and output-upload requests route to this skill.
- Mirrored the same content under `plugins/capgo-cloud/skills/capgo-native-builds` so marketplace exposure stays consistent.
- Extended `scripts/lint-skills.mjs` to fail when the Capgo Native Builds root and plugin copies differ.

## Business Impact (AI generated)

- Improves agent success rate for Capgo Build onboarding and support flows.
- Reduces failed build attempts caused by missing login, missing credentials, wrong output destination, or platform-specific signing gaps.
- Makes it easier for users to reach a successful native build and understand when to use store upload versus temporary output links.

## Testing (AI generated)

- [x] Ran `bun run lint-skills`.
- [x] Ran `git diff --check`.
- [x] Verified the root skill and plugin skill copies match exactly.
- [x] Waited for GitHub lint, Socket, and CodeRabbit checks after the first push; all passed before the follow-up commit.

## Not Tested (AI generated)

- [ ] Did not run live Capgo native builds because this change only updates skill documentation and lint validation.
- [ ] Did not run local skillgrade because it requires `ENABLE_SKILLGRADE=1` and `ANTHROPIC_API_KEY`; CI runs it as part of lint when secrets are available.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major rewrite/expansion of native builds docs: detailed iOS/Android onboarding and build flows, when-to-use guidance, authentication precedence, signing credential management, pre-build checks, request examples, CI secrets guidance, troubleshooting mappings, and updated reference links; version/date bumped to 1.1.0.
* **Chores**
  * Linting enhanced to validate mirrored skill files exist and match across canonical and plugin locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->