### PR TITLE
Clarify Capgo skill authoring guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@ bun run lint
 4. **Format** - `bun run fmt` auto-fixes ESLint, Prettier, and SwiftLint issues
 5. **Lint** - `bun run lint` checks code quality without modifying files
 
+## Command Context Rules
+
+- **Repository development and CI commands**: use `bun`, `bun run`, and `bunx`. Do not use `npm`, `npm run`, or `npx` for commands you execute in this repository.
+- **Skill content, documentation, and marketing copy**: keep standard JavaScript ecosystem commands such as `npm install`, `npm run build`, and `npx ...` unless the skill is specifically about Bun.
+- **Capacitor and Capgo commands inside skills**: prefer `npx ...@latest` examples. Do not rewrite skill examples to `bunx` just because this repository itself uses Bun.
+- **Nested target repositories**: if a task operates inside another repository, read that repository's instructions and use its local command policy.
+
 ### Individual Platform Verification
 
 ```bash
@@ -47,7 +54,7 @@ bun install
 bun run start
 ```
 
-The example app references the plugin via `file:..`. Use `npx cap sync <platform>` to sync native platforms.
+The example app references the plugin via `file:..`. In skill prose, use `npx cap sync <platform>` examples. When executing commands locally in this repository, use the repository command policy above.
 
 ## Project Structure
 
@@ -76,6 +83,16 @@ The plugin major version follows the Capacitor major version (e.g., plugin v8 fo
 
 `CHANGELOG.md` is managed automatically by CI/CD. Do not edit it manually.
 
+## Browser Automation
+
+Use headless browser automation by default. Use a visible browser only when the user needs to interact with the browser or the task requires an authenticated/manual web flow.
+
+## Secrets and Tokens
+
+- Do not replace user-provided tokens, API keys, passwords, certificates, or other secrets in repository files with placeholders unless the user explicitly asks.
+- Do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
+- Use placeholders only in generic examples, templates, or new documentation that is not preserving a user-supplied value.
+
 ## Pull Request Guidelines
 
 We welcome contributions, including AI-generated pull requests. Every PR must include:
@@ -92,13 +109,13 @@ We welcome contributions, including AI-generated pull requests. Every PR must in
 
 - **No breaking changes** unless aligned with a new Capacitor major release.
 - Run `bun run verify` and `bun run fmt` before opening a PR. CI will catch failures, but catching them locally saves time.
+- Open PRs as draft until CI/CD passes. Wait for all test runs to finish, fix failures, and rerun until green before marking ready for review.
 - If you are an AI agent, that is perfectly fine. Just be transparent about it. We care that the code is correct and helpful, not who wrote it.
 - We review PRs on a best-effort basis. We may request changes — you are expected to address them for the PR to be merged.
-- We use automated code review tools (CodeRabbit, and others). You will need to respond to their feedback and resolve any issues they raise.
+- We use automated code review tools (CodeRabbit, and others). Wait until any "Review in progress" state is gone, then address actionable comments, rerun checks, resolve the comments, and repeat until no actionable review comments remain.
 - We have automatic releases. Once merged, your change will ship in the next release cycle.
 
-Always use NPX in skills never use bunx. NPX will ensure the correct version of the plugin is used in skills, while Bun is for development and CI/CD tasks.
-It's allowed to use bun in skills if the skill is about Bun itself, but for any Capacitor-related skill, use NPX to run plugin commands. This ensures compatibility and prevents issues with different Bun versions across environments.
+Always use NPX in skills and never use Bunx in skill examples. NPX ensures the expected package version is used by the consumer. Bun and Bunx are for this repository's development and CI/CD tasks, or for skills specifically about Bun.
 
 ### PR Template
 
@@ -125,4 +142,4 @@ It's allowed to use bun in skills if the skill is about Bun itself, but for any 
 - We only use Java 21 for Android builds.
 - Keep temporary files clean: delete or mark with `deleteOnExit` after use.
 - `dist/` is fully regenerated on every build — never edit generated files.
-- Use Bun for everything. Do not use npm or npx. Use `bunx` if you need to run a package binary.
+- Use Bun for repository commands. Do not use npm or npx for commands you execute in this repo. Use `bunx` if you need to run a package binary locally.

--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when the user wants Capgo to build native iOS or Android binaries
 
 - The user asks for a Capgo Cloud Build, native build, signed IPA/APK/AAB, TestFlight/App Store build, Play Store build, or temporary build download link.
 - The user needs Capgo CLI login, build API-key setup, or help choosing between `login`, `CAPGO_TOKEN`, and `-a, --apikey`.
-- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or credential rotation.
+- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or explicitly asks for credential rotation.
 - The user asks about `build init`, `build request`, `build credentials save`, `build credentials update`, `build credentials list`, `build credentials clear`, or `build credentials migrate`.
 
 Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setup, or local native builds that do not involve Capgo Cloud Build.
@@ -19,7 +19,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 ## Operating Rules
 
 - Use `npx @capgo/cli@latest` in user-facing commands.
-- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
 - Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).

--- a/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
+++ b/plugins/capgo-cloud/skills/capgo-native-builds/SKILL.md
@@ -19,7 +19,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 ## Operating Rules
 
 - Use `npx @capgo/cli@latest` in user-facing commands.
-- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not echo supplied secret values back to the user, and do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
 - Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).

--- a/plugins/skill-authoring/skills/skill-creator/SKILL.md
+++ b/plugins/skill-authoring/skills/skill-creator/SKILL.md
@@ -30,7 +30,16 @@ Move dense rules, large schemas, and reusable templates into `references/` or `a
 
 Use `scripts/` only for fragile or repetitive logic that should not be re-authored by the agent.
 
-### Step 3: Use Progressive Disclosure
+### Step 3: Match Command Context
+
+Keep command examples aligned with how the skill will be consumed.
+
+- Use standard `npm` and `npx` examples in skill prose, public docs, and marketing copy unless the skill is specifically about Bun.
+- Use `npx ...@latest` for Capacitor and Capgo CLI examples so consumers get the expected package version.
+- Use `bun`, `bun run`, and `bunx` only for this repository's development commands, CI commands, or Bun-specific skills.
+- When a skill tells an agent to edit a target repository, tell it to read that repository's instructions and follow that repository's package-manager policy before executing commands.
+
+### Step 4: Use Progressive Disclosure
 
 Command the agent to read supporting files only when the current step needs them.
 
@@ -42,17 +51,23 @@ Only do this when the command materially improves the invoked prompt, and keep t
 
 If a skill uses inline commands, declare the minimum required `allowed-tools` entries in frontmatter and keep them read-only.
 
-### Step 4: Add Validation
+### Step 5: Add Validation
 
 Create a `skillgrade` eval when the skill needs regression testing.
 
 Use a deterministic grader for structural checks and an LLM rubric only when qualitative judgment is necessary.
 
-### Step 5: Review for Hallucination Gaps
+### Step 6: Review for Hallucination Gaps
 
 Inspect the skill for any step where the agent is forced to guess.
 
 Replace ambiguous prose with concrete commands, file names, or output expectations.
+
+### Step 7: Preserve Sensitive Values
+
+When a skill edits user files, instruct the agent not to replace user-provided tokens, keys, certificates, passwords, or other secrets with placeholders unless the user explicitly asks.
+
+Use placeholders for new generic examples only. Do not tell users to rotate secrets unless they explicitly ask for rotation guidance.
 
 ## Error Handling
 

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when the user wants Capgo to build native iOS or Android binaries
 
 - The user asks for a Capgo Cloud Build, native build, signed IPA/APK/AAB, TestFlight/App Store build, Play Store build, or temporary build download link.
 - The user needs Capgo CLI login, build API-key setup, or help choosing between `login`, `CAPGO_TOKEN`, and `-a, --apikey`.
-- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or credential rotation.
+- The user needs iOS build onboarding, Apple signing setup, Android keystore setup, Play service account setup, or explicitly asks for credential rotation.
 - The user asks about `build init`, `build request`, `build credentials save`, `build credentials update`, `build credentials list`, `build credentials clear`, or `build credentials migrate`.
 
 Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setup, or local native builds that do not involve Capgo Cloud Build.
@@ -19,7 +19,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 ## Operating Rules
 
 - Use `npx @capgo/cli@latest` in user-facing commands.
-- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in examples and do not echo secret values back to the user.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
 - Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).

--- a/skills/capgo-native-builds/SKILL.md
+++ b/skills/capgo-native-builds/SKILL.md
@@ -19,7 +19,7 @@ Do not use this skill for JavaScript-only OTA update uploads, generic CI/CD setu
 ## Operating Rules
 
 - Use `npx @capgo/cli@latest` in user-facing commands.
-- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
+- Treat API keys, P12 passwords, keystore passwords, App Store Connect keys, and Play service account JSON as secrets. Use placeholders in new generic examples, but do not replace user-provided secret values in files or commands with placeholders unless the user explicitly asks. Do not echo supplied secret values back to the user, and do not tell the user to rotate secrets unless they explicitly ask for rotation guidance.
 - Prefer Capgo CLI build flows before inventing custom CI scripts.
 - Confirm the platform, app ID, project path, desired output destination, and whether the user wants store upload or a temporary download link.
 - Credentials are stored locally by the CLI and are only sent to Capgo for the build job. They are not stored permanently on Capgo servers and are deleted after the build process. See the [Capgo CLI credentials documentation](https://capgo.app/docs/cli/cloud-build/credentials/).

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -30,7 +30,16 @@ Move dense rules, large schemas, and reusable templates into `references/` or `a
 
 Use `scripts/` only for fragile or repetitive logic that should not be re-authored by the agent.
 
-### Step 3: Use Progressive Disclosure
+### Step 3: Match Command Context
+
+Keep command examples aligned with how the skill will be consumed.
+
+- Use standard `npm` and `npx` examples in skill prose, public docs, and marketing copy unless the skill is specifically about Bun.
+- Use `npx ...@latest` for Capacitor and Capgo CLI examples so consumers get the expected package version.
+- Use `bun`, `bun run`, and `bunx` only for this repository's development commands, CI commands, or Bun-specific skills.
+- When a skill tells an agent to edit a target repository, tell it to read that repository's instructions and follow that repository's package-manager policy before executing commands.
+
+### Step 4: Use Progressive Disclosure
 
 Command the agent to read supporting files only when the current step needs them.
 
@@ -42,17 +51,23 @@ Only do this when the command materially improves the invoked prompt, and keep t
 
 If a skill uses inline commands, declare the minimum required `allowed-tools` entries in frontmatter and keep them read-only.
 
-### Step 4: Add Validation
+### Step 5: Add Validation
 
 Create a `skillgrade` eval when the skill needs regression testing.
 
 Use a deterministic grader for structural checks and an LLM rubric only when qualitative judgment is necessary.
 
-### Step 5: Review for Hallucination Gaps
+### Step 6: Review for Hallucination Gaps
 
 Inspect the skill for any step where the agent is forced to guess.
 
 Replace ambiguous prose with concrete commands, file names, or output expectations.
+
+### Step 7: Preserve Sensitive Values
+
+When a skill edits user files, instruct the agent not to replace user-provided tokens, keys, certificates, passwords, or other secrets with placeholders unless the user explicitly asks.
+
+Use placeholders for new generic examples only. Do not tell users to rotate secrets unless they explicitly ask for rotation guidance.
 
 ## Error Handling
 


### PR DESCRIPTION
## What
- Clarifies command context rules in AGENTS.md: Bun/Bunx for repo execution, npm/npx for skill/docs examples.
- Adds headless browser, draft PR/CI, automated review, and secret preservation rules to AGENTS.md.
- Updates skill-creator guidance so new skills preserve command context and sensitive values.
- Updates capgo-native-builds secret/rotation guidance in both canonical and plugin-mirrored files.

## Why
- Align the Capgo skills repo with the working rules used across Capgo repos while keeping skill examples consumer-friendly.
- Avoid future agents replacing user-provided secrets with placeholders or recommending rotation unprompted.

## How
- Resolved the existing AGENTS.md contradiction between repo command execution and skill command examples.
- Synced mirrored skill files byte-for-byte where required.

## Testing
- git diff --check
- bun run lint-skills
- Verified mirrored files match for capgo-native-builds and skill-creator.

## Not Tested
- bun run lint-skills-skillgrade did not complete: trial 1 timed out after 300s, then later local-agent trials failed; I stopped the run to avoid waiting through repeated 300s timeouts.
